### PR TITLE
Switch to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,6 @@ inputs:
     required: false
     default: ''
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'prepare.js'
   post: 'analyze.js'


### PR DESCRIPTION
Avoids warnings because of GitHub's switch to node20.

Tested on the new sequencer mirror (https://github.com/epics-modules/sequencer/actions/runs/8031312864)

This should also get a new version tag, probably?!